### PR TITLE
Fix compilation error with GHC 9.0

### DIFF
--- a/src/Database/PostgreSQL/Transact.hs
+++ b/src/Database/PostgreSQL/Transact.hs
@@ -57,7 +57,7 @@ instance (MonadIO m, MonadMask m) => MonadCatch (DBT m) where
     let setup = catch (restore act) $ \e -> do
                   liftIO $ Simple.rollbackToSavepoint conn sp
                     `catch` (\re -> if isNoTransaction re then pure () else throwM re)
-                  if typeRep (Proxy @ Abort) == typeOf e
+                  if typeRep (Proxy @Abort) == typeOf e
                     then (throwM Abort)
                     else unDBT $ handler e
 


### PR DESCRIPTION
The extraneous space between the @ and the type leads to a compilation error: 

```
src/Database/PostgreSQL/Transact.hs:61:37: error:
    Variable not in scope: (@) :: Proxy t0 -> Abort -> proxy0 a0
   |
61 |                   if typeRep (Proxy @ Abort) == typeOf e
   |                                     ^
```

cc @jfischoff 